### PR TITLE
chore: upgrade git-lfs version to 3.7.0

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -32,7 +32,7 @@ fi
 echo "-----> Install Git LFS"
 (
     pushd /tmp
-    wget https://github.com/git-lfs/git-lfs/releases/download/v2.13.3/git-lfs-linux-amd64-v2.13.3.tar.gz \
+    wget https://github.com/git-lfs/git-lfs/releases/download/v3.7.0/git-lfs-linux-amd64-v3.7.0.tar.gz \
          -O git-lfs.tar.gz
     tar -xvf /tmp/git-lfs.tar.gz
     popd
@@ -44,7 +44,7 @@ echo "-----> Download Git LFS assets"
     pushd "$build_dir"
 
     mkdir -p .heroku/bin
-    mv /tmp/git-lfs .heroku/bin/
+    mv /tmp/git-lfs-3.7.0/git-lfs .heroku/bin/
 
     mkdir -p .profile.d
     cat <<"EOF" > .profile.d/heroku-buildpack-git-lfs.sh


### PR DESCRIPTION
My previous PR had a problem with the path resolution of the binary. In this one, we are fixing that problem. 